### PR TITLE
Enhancement: Enable Resolution of Nested Object Properties

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -16,5 +16,6 @@ export default class State<T extends object> {
   private isNumericMath;
   private mutateNestedObject;
   private triggerUpdate;
+  private getNestedPropertyValue;
 }
 export {};

--- a/src/test/state.spec.ts
+++ b/src/test/state.spec.ts
@@ -5,15 +5,21 @@ import State from '../';
 describe('State', () => {
   describe('#reactive', () => {
     it('should create a reactive property for a nested object', () => {
-      const data = {a: 1, b: 2, c: {d: 2}};
+      const data = {
+        a: 1,
+        b: 2,
+        c: {d: 2, e: 5, z: {r: 3, y: 9, t: {a: 4, b: 5}}},
+      };
       const state = new State(data);
-      state.reactive('c.d', '2 * $a + $b');
-      state.state.a = 1;
-      expect(state.state.c.d).to.equal(4);
-      state.state.a = 3;
-      expect(state.state.c.d).to.equal(8);
-      state.state.b = 4;
-      expect(state.state.c.d).to.equal(10);
+      state.reactive('c.d', '2 *  $a + $c.e + $c.z.r + $c.z.t.b');
+      state.state.c.e = 5;
+      expect(state.state.c.d).to.equal(15);
+      state.state.c.z.r = 2;
+      expect(state.state.c.d).to.equal(14);
+      state.state.c.z.t.b = 11;
+      expect(state.state.c.d).to.equal(20);
+      state.state.a = 2;
+      expect(state.state.c.d).to.equal(22);
     });
   });
 


### PR DESCRIPTION
Hello dear Nima,

This pull request addresses the issues described in [#25](https://github.com/nimahkh/soft_bun/issues/25)

I've made some crucial bug fixes that enhance the functionality of the pairValues method and introduce a new method called getNestedPropertyValue. These changes allow for the seamless handling of nested property paths within reactive expressions. Below, I've outlined the modifications and their benefits:


1. Modified Regular Expression in pairValues Method
2. Added getNestedPropertyValue Method
3. Updated pairValues Method to Utilize getNestedPropertyValue 


These changes collectively ensure that the codebase now offers robust support for accessing nested properties within reactive expressions.

Thank you for considering this pull request. I eagerly await your feedback and am prepared to address any queries or concerns you may have.